### PR TITLE
README clarification about how to get uTorrent to seed your files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you don't have an index.html in the torrent directory, you will receive a war
 ### Seeding
 __TODO__
 
-Once you've generated a torrent, you'll need to seed it in order for other people to view its contents. To do so, add the torrent to uTorrent, set to find the files in their original location.
+Once you've generated a torrent, you'll need to seed it in order for other people to view its contents. To do so, add the torrent to uTorrent and make sure that the original files are in your default download directory.
 
 Note that seeding a torrent using clients other than uTorrent or BitTorrent may result in it not being reachable in the Maelstrom browser via magnet link.
 


### PR DESCRIPTION
I was tripped up for a bit on how to "set to find the files in their original location" in uTorrent, as it says in the README.  It was just trying to download the files when I added the torrent.  I ended up adding my files to my default download directory and that fixed it and made uTorrent seed the files instead.

I wanted to add a quick clarification on this in case it helps other people.  Does this language make sense, or is there a better way to do it?